### PR TITLE
Python3 style exception compatibility

### DIFF
--- a/sslserver/management/commands/runsslserver.py
+++ b/sslserver/management/commands/runsslserver.py
@@ -130,7 +130,8 @@ class Command(runserver.Command):
             server.set_app(handler)
             server.serve_forever()
 
-        except WSGIServerException, e:
+        except WSGIServerException:
+            e = sys.exc_info()[1]
             # Use helpful error messages instead of ugly tracebacks.
             ERRORS = {
                 13: "You don't have permission to access that port.",


### PR DESCRIPTION
Edited exception to be compatible with Python 3+ as well as 2.5-. This was the only incompatibility I suffered using django-sslserver in Python 3.4.
