### PR TITLE
Use TLS instead of SSL 3.0.

### DIFF
--- a/sslserver/management/commands/runsslserver.py
+++ b/sslserver/management/commands/runsslserver.py
@@ -28,7 +28,7 @@ class SecureHTTPServer(WSGIServer):
         super(SecureHTTPServer, self).__init__(address, handler_cls)
         self.socket = ssl.wrap_socket(self.socket, certfile=certificate,
                                       keyfile=key, server_side=True,
-                                      ssl_version=ssl.PROTOCOL_SSLv3,
+                                      ssl_version=ssl.PROTOCOL_TLSv1,
                                       cert_reqs=ssl.CERT_NONE)
 
 


### PR DESCRIPTION
SSL 3 is on its way out, and will be disabled by default in November's release of Firefox: https://blog.mozilla.org/security/2014/10/14/the-poodle-attack-and-the-end-of-ssl-3-0/

I don't care very much about the protocol or cipher used as long as it's only bound to localhost, but using a protocol not supported by the browser we're developing with is a problem.
