### PR TITLE
Django 1.8 Compatibility - Set Custom Address/Port

### DIFF
--- a/sslserver/management/commands/runsslserver.py
+++ b/sslserver/management/commands/runsslserver.py
@@ -47,6 +47,9 @@ def default_ssl_files_dir():
 
 class Command(runserver.Command):
     option_list = runserver.Command.option_list + (
+        make_option("--addrport",                                    
+                    default="127.0.0.1:8000",                                
+                    help="Set Custom address/port (Default:127.0.0.1:8000)"),
         make_option("--certificate",
                     default=os.path.join(default_ssl_files_dir(),
                                          "development.crt"),


### PR DESCRIPTION
Added the ability to set a custom address/port in Django 1.8. In Django 1.7 and previous versions this could be set as an argument:

./manage.py runsslserver 0:8080 --certificate ...

Now you must pass that argument as an option with --addrport (In django's new runserver command), but runsslserver doesn't recognize that option as valid which causes it to send a false negative error message. This change will fix that.