### PR TITLE
Override add_arguments instead of adding to option_list

### DIFF
--- a/sslserver/management/commands/runsslserver.py
+++ b/sslserver/management/commands/runsslserver.py
@@ -46,25 +46,23 @@ def default_ssl_files_dir():
 
 
 class Command(runserver.Command):
-    option_list = runserver.Command.option_list + (
-        make_option("--addrport",                                    
-                    default="127.0.0.1:8000",                                
-                    help="Set Custom address/port (Default:127.0.0.1:8000)"),
-        make_option("--certificate",
-                    default=os.path.join(default_ssl_files_dir(),
-                                         "development.crt"),
-                    help="Path to the certificate"),
-        make_option("--key",
-                    default=os.path.join(default_ssl_files_dir(),
-                                         "development.key"),
-                    help="Path to the key file"),
-        make_option("--nostatic", dest='use_static_handler',
-                    action='store_false', default=None,
-                    help="Don't use StaticFilesHandler. Use this if using a "
-                         "third-party handler (e.g., WhiteNoise)."),
-        make_option("--static", dest='use_static_handler',
-                    action='store_true')
-    )
+    def add_arguments(self, parser):
+        super(Command, self).add_arguments(parser)
+        parser.add_argument("--addrport",
+                            default="127.0.0.1:8000",
+                            help="Set Custom address/port (Default:127.0.0.1:8000)"),
+        parser.add_argument("--certificate",
+                            default=os.path.join(default_ssl_files_dir(),
+                                "development.crt"),
+                            help="Path to the certificate"),
+        parser.add_argument("--key",
+                            default=os.path.join(default_ssl_files_dir(),
+                                "development.key"),
+                            help="Path to the key file"),
+        parser.add_argument("--nostatic", dest='use_static_handler',
+                            action='store_false', default=None),
+        parser.add_argument("--static", dest='use_static_handler',
+                            action='store_true'),
 
     help = "Run a Django development server over HTTPS"
 


### PR DESCRIPTION
In Django 1.8+ we can override `add_arguments` to add to the list of arguments inherited from the parent management command:

https://docs.djangoproject.com/en/1.8/howto/custom-management-commands/#django.core.management.BaseCommand.add_arguments

My particular interest here was to get autoload behavior with `runsslserver`, which we can do by including the `--noreload` argument which, in the parent class `runserver.Command` defaults to False.

A few things I'd appreciate input from others on:

* What versions of Django is django-sslserver interested in supporting?  Is there an easy way to inherit `runserver.Command` default arguments without restricting django-sslserver to 1.8+?  The implementation this PR replaces (e.g. `option_list = runserver.Command.option_list + (...` doesn't seem to pull in the parent class's arguments.
* I notice that Django `runserver.Command` also provides a positional `addrport` argument, so we may also be able to remove the `--addrport` argument added in `runsslserver.Command`.  Seem reasonable?
* `runserver.Command` also provides a `--nostatic` argument -- is is possible/desirable for django-sslserver to use that argument instead of adding its own `--static` argument, or are these independent concerns?

The effect of this PR: https://gist.github.com/jasonm/74fe211cfde7679473f4