### PR TITLE
Remove --addrport option

### DIFF
--- a/sslserver/management/commands/runsslserver.py
+++ b/sslserver/management/commands/runsslserver.py
@@ -48,9 +48,6 @@ def default_ssl_files_dir():
 class Command(runserver.Command):
     def add_arguments(self, parser):
         super(Command, self).add_arguments(parser)
-        parser.add_argument("--addrport",
-                            default="127.0.0.1:8000",
-                            help="Set Custom address/port (Default:127.0.0.1:8000)"),
         parser.add_argument("--certificate",
                             default=os.path.join(default_ssl_files_dir(),
                                 "development.crt"),


### PR DESCRIPTION
This option is redundant and is covered by the same-named positional argument (addrport) used in 'runserver'.

After looking at the underlying code, there is no good way of using '--addrport' in addition to the positional argument without hacking it in.

I believe this is the simplest approach to solving the problem.