### PR TITLE
Discourage production use

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,6 +4,13 @@ Django SSL Server
 
 Django SSL Server is a SSL-enabled development server for the Django Framework.
 
+Please note that this `should not be used for production setups
+<https://docs.djangoproject.com/en/1.11/ref/django-admin/#runserver>`_. This
+app is intended for special use-cases. Most people should instead do a proper
+`production deplyoment
+<https://docs.djangoproject.com/en/1.11/howto/deployment/>`_ where a real
+webserver such as Apache or NGINX handles SSL.
+
 Getting Started
 ===============
 
@@ -38,15 +45,13 @@ Django SSL Server ships "batteries included" with a self-signed server certifica
 the server is effectively telling the user, "I'm such-and-such server, because I said so". Whereas, with a commercial
 SSL certificate, the server tells the user, "I'm Bank of America, because VeriSign said so (or any other commercial certificate authority)."
 
-**Using self-signed certificates for development is fine, but not for production**. In production, your users will see
-the same ugly certificate warning you're seeing now. That's bad.
-
 There are two options for making the certificate warning go away in development:
 
 **Option 1**: Tell your browser to explicitly trust the certificate. You can do this in your browser's "advanced settings"
 tab, by installing ``sslserver/certs/development.crt`` as a trusted certificate. The mechanism for this varies from browser to browser.
 
-**Option 2**: Use a commercial SSL certificate. If you have a certificate/key pair from a commercial certificate authority,
+**Option 2**: Use a certificate from a CA that your browser trusts, for example `Letsencrypt <https://letsencrypt.org>`_.
+If you have a certificate/key pair from a certificate authority,
 you can tell Django SSL Server to use it with the following arguments::
 
   $ python manage.py runsslserver --certificate /path/to/certificate.crt --key /path/to/key.key


### PR DESCRIPTION
* Add a note to the top of the README, with links to the relevant Django documentation.
* Remove the explicit mention of certificates for production setups.
* Mention Letsencrypt instead of commercial CAs.

Refs #50.