### PR TITLE
Change distutils to setuptools

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,9 @@
+include *.txt
+include AUTHORS
+include LICENSE
+include README.rst
+recursive-include sslserver development.*
+
+recursive-exclude demo *
+global-exclude *.pyc *.pyo
+global-exclude .git

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
-from distutils.core import setup
+#!/usr/bin/env python
+from setuptools import setup, find_packages
 import sslserver
 
 setup(name="django-sslserver",
@@ -7,16 +8,10 @@ setup(name="django-sslserver",
       author_email="tjdziuba@gmail.com",
       description="An SSL-enabled development server for Django",
       url="https://github.com/teddziuba/django-sslserver",
-      packages=["sslserver",
-                "sslserver.management",
-                "sslserver.management.commands"],
-      package_dir={"sslserver": "sslserver"},
-      package_data={"sslserver": ["certs/development.crt",
-                                  "certs/development.key"]},
-      install_requires=["setuptools",
-                        "Django >= 1.8"],
+      packages=find_packages(exclude=['demo']),
+      include_package_data=True,
+      install_requires=["Django >= 1.8"],
       license="MIT",
-
       classifiers=[
           "Environment :: Web Environment",
           "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
I tested that after `python setup.py install`, cert and key files are in site-packages/.