### PR TITLE
Fixes for Django 5 and Python 3.12

### DIFF
--- a/sslserver/management/commands/runsslserver.py
+++ b/sslserver/management/commands/runsslserver.py
@@ -48,10 +48,9 @@ except ImportError:
 class SecureHTTPServer(ThreadedWSGIServer):
     def __init__(self, address, handler_cls, certificate, key, ipv6=False):
         super(SecureHTTPServer, self).__init__(address, handler_cls, ipv6=ipv6)
-        self.socket = ssl.wrap_socket(self.socket, certfile=certificate,
-                                      keyfile=key, server_side=True,
-                                      ssl_version=_ssl_version,
-                                      cert_reqs=ssl.CERT_NONE)
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        context.load_cert_chain(certfile=certificate, keyfile=key)
+        self.socket = context.wrap_socket(self.socket, server_side=True)
 
 
 class WSGIRequestHandler(WSGIRequestHandler):


### PR DESCRIPTION
This fixes the issue of `AttributeError: module 'ssl' has no attribute 'wrap_socket'`, gleaned from a similar issue on [eventlet](https://github.com/eventlet/eventlet/issues/795#issuecomment-1818471152). 

Tested with Django 5.0.3 and Python 3.12 (should also work for 3.10 & 3.11)