### PR TITLE
FIXED -> ssl module does not have an attribute wrap_socket

### DIFF
--- a/sslserver/management/commands/runsslserver.py
+++ b/sslserver/management/commands/runsslserver.py
@@ -48,10 +48,9 @@ except ImportError:
 class SecureHTTPServer(ThreadedWSGIServer):
     def __init__(self, address, handler_cls, certificate, key, ipv6=False):
         super(SecureHTTPServer, self).__init__(address, handler_cls, ipv6=ipv6)
-        self.socket = ssl.wrap_socket(self.socket, certfile=certificate,
-                                      keyfile=key, server_side=True,
-                                      ssl_version=_ssl_version,
-                                      cert_reqs=ssl.CERT_NONE)
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        context.load_cert_chain(certfile=certificate, keyfile=key)
+        self.socket = context.wrap_socket(self.socket, server_side=True)
 
 
 class WSGIRequestHandler(WSGIRequestHandler):


### PR DESCRIPTION
ERROR: ssl module does not have an attribute wrap_socket

wrap_socket function has been deprecated since Python 3.7 and was removed in Python 3.10.

Fixed by usING SSLContext instead of wrap_socket